### PR TITLE
Fix internal server error when ship code halts

### DIFF
--- a/src/jvmMain/kotlin/halloween2020/VmController.kt
+++ b/src/jvmMain/kotlin/halloween2020/VmController.kt
@@ -112,7 +112,8 @@ class VmSubController(executable: Executable, val game: Game, val player: Int, v
         val s = ship(shipName)
         while (s.alive && s.energy > 0 && !calledTick) {
             s.energy--
-            vm.executeInstruction()
+            if (!vm.executeInstruction())
+                s.alive = false
         }
     }
 }


### PR DESCRIPTION
A ship program which terminates will cause an internal server error:
```
se.jsannemo.spooky.vm.VmException: Instruction pointer out-of-bounds
        at se.jsannemo.spooky.vm.SpookyVm.executeInstruction(SpookyVm.java:67)
        at halloween2020.VmSubController.tick(VmController.kt:115)
```
This change destroys the ship if the ship code halts. An alternative could be to keep the ship alive but stop executing instructions by adding a 'hasHalted' boolean. 